### PR TITLE
fix warning for undef values

### DIFF
--- a/lib/Spreadsheet/GenerateXLSX.pm
+++ b/lib/Spreadsheet/GenerateXLSX.pm
@@ -91,7 +91,7 @@ my $generate_sheet = sub {
 
         foreach my $cell (@$row) {
             $sheet->write($row_num, $col_num, $cell, $formats->{$celltype});
-            if (!defined($widths[$col_num]) || length($cell) > $widths[$col_num]) {
+            if (!defined($widths[$col_num]) || (defined($cell) && length($cell) > $widths[$col_num])) {
                 $widths[$col_num] = length($cell);
             }
             $col_num++;

--- a/t/03-generate.t
+++ b/t/03-generate.t
@@ -1,0 +1,31 @@
+#!perl
+
+#
+# 03-generate.t
+#
+# generate a spreadsheet and check for warnings;
+#
+
+use strict;
+use warnings;
+
+use Test::Needs {
+    'Spreadsheet::ParseXLSX' => 0.26,
+};
+use Test::More 0.88 tests => 1;
+use Test::Warn 0.36;
+use Spreadsheet::GenerateXLSX qw/ generate_xlsx /;
+
+my $stem = $0;
+$stem =~ s/\.t$//;
+my $filename = "${stem}.xlsx";
+
+my $var;
+my $data = [ [ 'A', 'B', 'C' ], [ $var, undef, '' ] ];
+
+warnings_like { generate_xlsx( $filename, $data ) } [], 'no warnings for undefined values';
+
+unlink($filename);
+if ($@) {
+    BAIL_OUT($@);
+}


### PR DESCRIPTION
Spreadsheet::GenerateXLSX throws a warning if a cell value is undefined:

"Use of uninitialized value in numeric gt (>) at /.../Spreadsheet/GenerateXLSX.pm line 94"

```perl
use strict;
use warnings;

use File::Temp qw/ tempfile tempdir /;
use Spreadsheet::GenerateXLSX qw/ generate_xlsx /;
use Test::More;
use Test::Warn;

my $var;

my $rows = [ [ 'A', 'B', 'C' ], [ $var, undef, '' ] ];

my ( $fh, $filename ) = tempfile( SUFFIX => '.xlsx' );

warnings_like { generate_xlsx( $filename, $rows ) }[
    qr/Use of uninitialized value in numeric gt .*/,
    qr/Use of uninitialized value in numeric gt .*/
];

done_testing;
```